### PR TITLE
Get rid of cereal patch on Android

### DIFF
--- a/src/cereal/include/details/util.hpp
+++ b/src/cereal/include/details/util.hpp
@@ -52,18 +52,7 @@ namespace cereal
 } // namespace cereal
 #else // clang or gcc
 
-// Patch by Alex Zolotarev to avoid Cereal compilation error for Android.
-#ifndef ANDROID
 #include <cxxabi.h>
-#else
-namespace __cxxabiv1 {
-extern "C" char * __cxa_demangle(const char *mangled_name, char *output_buffer, size_t *length, int *status);
-}
-namespace abi = __cxxabiv1;
-// This one was copied directly from the NDK r10d.
-#include "../../cxa_demangle.cpp"
-#endif
-
 #include <cstdlib>
 
 namespace cereal


### PR DESCRIPTION
Our NDK (r19c) don't need this patch to compile