### PR TITLE
UIWebView -> WKWebView

### DIFF
--- a/examples/ios/SampleClient.xcodeproj/project.pbxproj
+++ b/examples/ios/SampleClient.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		6BDEF0621A3CF2D100054FAC /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6BDEF0611A3CF2D100054FAC /* Images.xcassets */; };
 		6BDEF0651A3CF2D100054FAC /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6BDEF0631A3CF2D100054FAC /* LaunchScreen.xib */; };
 		6BDEF0711A3CF2D100054FAC /* SampleClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BDEF0701A3CF2D100054FAC /* SampleClientTests.m */; };
+		7A810A8D2524BF8C00E3F800 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A810A8C2524BF8C00E3F800 /* WebKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 		6BDEF06A1A3CF2D100054FAC /* SampleClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SampleClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6BDEF06F1A3CF2D100054FAC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6BDEF0701A3CF2D100054FAC /* SampleClientTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SampleClientTests.m; sourceTree = "<group>"; };
+		7A810A8C2524BF8C00E3F800 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +76,7 @@
 			files = (
 				6BDB7FDC1AA4884B0036C3CB /* AdSupport.framework in Frameworks */,
 				6B8A73891B260D600085EFE6 /* SystemConfiguration.framework in Frameworks */,
+				7A810A8D2524BF8C00E3F800 /* WebKit.framework in Frameworks */,
 				6BD1AAFD1A8E5AD8000CB093 /* libz.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -114,6 +117,7 @@
 				6BDEF0531A3CF2D100054FAC /* SampleClient */,
 				6BDEF06D1A3CF2D100054FAC /* SampleClientTests */,
 				6BDEF0521A3CF2D100054FAC /* Products */,
+				7A810A8B2524BF8C00E3F800 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -168,6 +172,14 @@
 				6BDEF06F1A3CF2D100054FAC /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		7A810A8B2524BF8C00E3F800 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7A810A8C2524BF8C00E3F800 /* WebKit.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/src/apple/alohalytics_objc.mm
+++ b/src/apple/alohalytics_objc.mm
@@ -41,7 +41,7 @@ SOFTWARE.
 #import <UIKit/UIDevice.h>
 #import <UIKit/UIScreen.h>
 #import <UIKit/UIApplication.h>
-#import <UIKit/UIWebView.h>
+#import <WebKit/WKWebView.h>
 #import <AdSupport/ASIdentifierManager.h>
 // Export user agent for HTTP module.
 NSString * gBrowserUserAgent = nil;
@@ -401,12 +401,28 @@ static NSString * gInstallationId = nil;
   instance.LogEvent("$launch", params);
 #if (TARGET_OS_IPHONE > 0)
   // Initialize User-Agent asynchronously and log additional system info for iOS, as it takes significant time at startup.
-  dispatch_async(dispatch_get_main_queue(), ^{
-    gBrowserUserAgent = [[[UIWebView alloc] initWithFrame:CGRectZero] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
-    if (shouldSendUpdatedSystemInformation) {
-      LogSystemInformation(gBrowserUserAgent);
-    }
-  });
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __block WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+        [webView evaluateJavaScript: @"navigator.userAgent"
+                  completionHandler:^(id _Nullable result, NSError * _Nullable error) {
+            if (result != nil && [result isKindOfClass:[NSString class]]) {
+                gBrowserUserAgent = (NSString *)result;
+                if (shouldSendUpdatedSystemInformation) {
+                    LogSystemInformation(gBrowserUserAgent);
+                }
+            } else if (error != nil) {
+                NSLog(@"Alohalytics ERROR: can not get userAgent: %@", error);
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                // we need reference to webView to keep it alive until
+                // this moment to prevent errors and assertions.
+                // If webView would be destroyed before `completionHandler`
+                // would be called or right after `completionHandler` finished
+                // we many errors in log.
+               webView = nil;
+            });
+        }];
+    });
 #else
   static_cast<void>(options);  // Unused variable warning fix.
 #endif  // TARGET_OS_IPHONE


### PR DESCRIPTION
UIWebView объявлена устаревшей, и что намного важнее
Apple не принимает новые приложения с использованием UIWebView.
Цитата из email от "App Store Connect":
> ITMS-90809: Deprecated API Usage - New apps that use UIWebView are no longer
>  accepted. Instead, use WKWebView for improved security and reliability. Learn
>   more (https://developer.apple.com/documentation/uikit/uiwebview).

`WKWebView` доступен начиная с iOS 8.0, поэтому не должно быть проблем с его использованием.